### PR TITLE
KrampNCF-RT widget: show both directions

### DIFF
--- a/Scriptable/krampncf-rt.js
+++ b/Scriptable/krampncf-rt.js
@@ -27,9 +27,8 @@ stack.layoutHorizontally();
 stack.topAlignContent();
 
 
-// PRIM realtime for one direction (widget param: 1 = Étampes→Austerlitz,
-// 2 = Austerlitz→Étampes; defaults to 1).
-const url = Conf.getUrlDeparturesPrimById(idDeparture || 1);
+// PRIM realtime for both boards (Étampes→Austerlitz and Austerlitz→Étampes).
+const url = Conf.getUrlDeparturesPrimByType('train');
 const req = new Request(url);
 const reqData = await req.loadJSON();
 


### PR DESCRIPTION
`KrampNCF-RT.js` was fetching a single PRIM board (`/departuresPrim/:id`) after the rewrite. This restores its previous behaviour of showing **both** directions (Étampes→Austerlitz and Austerlitz→Étampes) by calling `/departuresPrimByType/train`.

The widget's existing array branch (and the `delays` filter) already handle the two-board response — one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)