### PR TITLE
CI: update GitHub Actions to latest majors (Node 24)

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: ./Back
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -32,16 +32,16 @@ jobs:
     needs: check
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: godwin42sh/krampncf:latest


### PR DESCRIPTION
GitHub is deprecating the Node 20 runtime that the older action versions run on ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)), which surfaced as two `Node.js 20 is deprecated` warnings in CI.

Bumps every action to its latest major, all of which target Node 24:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | **v6** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/build-push-action` | v6 | **v7** |

`oven-sh/setup-bun` stays at `v2` — that's its latest major and it already runs on Node 24.

Clears both CI warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)