### PR TITLE
Add SIRI ET Lite realtime source (delays + docks, RER C + mainline Rémi)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ SNCF_API_KEY=
 # Optional overrides (defaults are set in docker-compose.yaml)
 #SNCF_API_URL=https://api.sncf.com/v1
 #SNCF_GTFSRT_URL=https://proxy.transport.data.gouv.fr/resource/sncf-ter-gtfs-rt-trip-updates
+# SIRI ET Lite (realtime departures with platforms, keyless). Defaults to the
+# national transport.data.gouv.fr proxy when unset.
+#SNCF_SIRI_ET_URL=https://proxy.transport.data.gouv.fr/resource/sncf-siri-lite-estimated-timetable
 
 # PRIM (default realtime source) — endpoints return 503 when unset
 #SNCF_API_PRIM_URL=https://prim.iledefrance-mobilites.fr/marketplace

--- a/Back/README.md
+++ b/Back/README.md
@@ -12,14 +12,21 @@ caches upstream responses in Redis, and documents itself with Swagger.
 
 | Source | Role | Status |
 |--------|------|--------|
-| **PRIM** (Île-de-France Mobilités SIRI Lite) | Realtime departures: time, delay, platform | ✅ **Default** |
+| **SIRI ET Lite** (national, transport.data.gouv.fr proxy) | Realtime departures with delay + platform, RER C **and** mainline Rémi, full calling pattern | ✅ **Recommended** |
+| **PRIM** (Île-de-France Mobilités SIRI Lite) | Realtime departures: time, delay, platform — RER C + partial TER | ✅ Working |
 | **GTFS-RT** (transport.data.gouv.fr proxy) | Realtime trip updates | ✅ Working |
 | **Navitia** (`api.sncf.com`) | Scheduled timetables (enriched by a realtime source) | ⚠️ Needs a valid API key |
 | **ter.sncf.com crawl** (direct + via FlareSolverr) | Legacy platform/departure scraper | ❌ Blocked by DataDome |
 
-The `crawlFlare` source is kept for reference but no longer works — SNCF put
-`garesetconnexions.sncf` behind DataDome, which FlareSolverr cannot pass. The
-default realtime method is therefore **`prim`**.
+**SIRI ET Lite** is the best source: keyless, national, and it carries the full
+calling list per train — so it covers both the RER C shuttle and the mainline
+Rémi (e.g. Paris-Austerlitz → Orléans calling at Étampes) that PRIM's IDFM feed
+doesn't publish, and it can tell definitively whether a train stops at Étampes.
+Its feed is a ~15 MB national XML fetched-and-cached like GTFS-RT.
+
+PRIM stays as a lighter IDFM-only source. The `crawlFlare` source is kept for
+reference but no longer works — SNCF put `garesetconnexions.sncf` behind
+DataDome, which FlareSolverr cannot pass.
 
 ## Quick start
 
@@ -46,7 +53,9 @@ and `deleted`.
 
 | Method & path | Description |
 |---------------|-------------|
-| `GET /departuresPrim/:id` | **Primary endpoint.** Realtime PRIM departures for a configured board (time + delay + dock). `?format=awtrix` returns a single Awtrix frame. |
+| `GET /departuresSiri/:id` | **Recommended.** Realtime SIRI ET departures for a board (delay + dock, RER C + Rémi). `?format=awtrix` returns a single Awtrix frame. |
+| `GET /departuresSiriByType/:type` | SIRI ET departures for every board of a given `type` (e.g. `train`). |
+| `GET /departuresPrim/:id` | Realtime PRIM departures for a configured board (time + delay + dock). `?format=awtrix` returns a single Awtrix frame. |
 | `GET /departuresPrimByType/:type` | PRIM departures for every board of a given `type` (e.g. `train`). |
 | `GET /departuresRT` | GTFS-RT realtime for both directions. |
 | `GET /departuresRT/:id` | GTFS-RT realtime for one line. |

--- a/Back/bun.lock
+++ b/Back/bun.lock
@@ -12,6 +12,7 @@
         "@nestjs/swagger": "^11.4.6",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
+        "fast-xml-parser": "^5.10.1",
         "gtfs-realtime-bindings": "^2.1.0",
         "ioredis": "^5.11.1",
         "nestjs-zod": "^5.4.0",
@@ -91,6 +92,8 @@
 
     "@nestjs/testing": ["@nestjs/testing@11.1.28", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0", "@nestjs/microservices": "^11.0.0", "@nestjs/platform-express": "^11.0.0" }, "optionalPeers": ["@nestjs/microservices", "@nestjs/platform-express"] }, "sha512-B+VgRxeLaH7jkOMgAyUP3N3rpFlisQ7JRxixRbgHvG6a0VgKbbkNSofKExexCgKmQQak80undb3+2kE1lUBmRQ=="],
 
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
     "@scarf/scarf": ["@scarf/scarf@1.4.0", "", {}, "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
@@ -160,6 +163,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
     "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
 
@@ -289,6 +294,10 @@
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
@@ -352,6 +361,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -445,6 +456,8 @@
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
@@ -519,6 +532,8 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "swagger-ui-dist": ["swagger-ui-dist@5.32.8", "", { "dependencies": { "@scarf/scarf": "=1.4.0" } }, "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA=="],
@@ -570,6 +585,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "xmlcreate": ["xmlcreate@2.0.4", "", {}, "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="],
 

--- a/Back/package.json
+++ b/Back/package.json
@@ -19,6 +19,7 @@
     "@nestjs/swagger": "^11.4.6",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
+    "fast-xml-parser": "^5.10.1",
     "gtfs-realtime-bindings": "^2.1.0",
     "ioredis": "^5.11.1",
     "nestjs-zod": "^5.4.0",

--- a/Back/src/config/env.validation.ts
+++ b/Back/src/config/env.validation.ts
@@ -18,6 +18,7 @@ export const envSchema = z.object({
   SNCF_API_URL: z.string().min(1),
   SNCF_API_KEY: z.string().min(1),
   SNCF_GTFSRT_URL: z.string().min(1),
+  SNCF_SIRI_ET_URL: z.string().optional(),
 
   SNCF_API_PRIM_URL: z.string().optional(),
   SNCF_API_PRIM_KEY: z.string().optional(),

--- a/Back/src/config/siri-data.ts
+++ b/Back/src/config/siri-data.ts
@@ -1,0 +1,27 @@
+import { SiriBoard } from "../types/SiriEt";
+
+// UIC stop codes as they appear in the SIRI ET feed (StopPointRef suffix).
+// Paris-Austerlitz is two stops there: the mainline station and the RER C one.
+const AUSTERLITZ_UICS = ["87547000", "87547026"];
+const ETAMPES_UICS = ["87545137"];
+
+const siriBoards: SiriBoard[] = [
+  {
+    id: 1,
+    departureName: "Étampes",
+    destinationName: "Austerlitz",
+    fromUics: ETAMPES_UICS,
+    toUics: AUSTERLITZ_UICS,
+    type: "train",
+  },
+  {
+    id: 2,
+    departureName: "Austerlitz",
+    destinationName: "Étampes",
+    fromUics: AUSTERLITZ_UICS,
+    toUics: ETAMPES_UICS,
+    type: "train",
+  },
+];
+
+export default siriBoards;

--- a/Back/src/departures/departures.controller.ts
+++ b/Back/src/departures/departures.controller.ts
@@ -166,6 +166,53 @@ export class DeparturesController {
     return this.departures.getPrimDeparturesByType(type);
   }
 
+  @Get("departuresSiri/:id")
+  @ApiOperation({
+    summary:
+      "Realtime departures from the national SIRI ET feed (delays + platforms, RER C and TER/Rémi)",
+  })
+  @ApiParam({ name: "id", type: Number, description: "Siri board id" })
+  @ApiOkResponse({
+    schema: {
+      oneOf: [
+        { $ref: getSchemaPath(DeparturesResponseDto) },
+        { $ref: getSchemaPath(AwtrixResponseDto) },
+      ],
+    },
+  })
+  @ApiNotFoundResponse({ description: "Siri board not found" })
+  @ApiServiceUnavailableResponse({
+    description: "SIRI ET feed could not be fetched",
+  })
+  async departuresSiri(
+    @Param("id", ParseIntPipe) id: number,
+    @Query() query: FormatQueryDto,
+  ): Promise<DeparturesResponse | AwtrixResponse> {
+    const departuresRes = await this.departures.getSiriBoard(id);
+
+    if (query.format === "awtrix") {
+      return this.departures.toAwtrix(departuresRes);
+    }
+
+    return departuresRes;
+  }
+
+  @Get("departuresSiriByType/:type")
+  @ApiOperation({
+    summary: "SIRI ET departures for every board of a given type",
+  })
+  @ApiParam({ name: "type", type: String, example: "train" })
+  @ApiOkResponse({ type: [DeparturesResponseDto] })
+  @ApiNotFoundResponse({ description: "Siri board not found" })
+  @ApiServiceUnavailableResponse({
+    description: "SIRI ET feed could not be fetched",
+  })
+  async departuresSiriByType(
+    @Param("type") type: string,
+  ): Promise<DeparturesResponse[]> {
+    return this.departures.getSiriBoardsByType(type);
+  }
+
   @Get("departuresCrawl/:id")
   @ApiOperation({
     summary: "Departures scraped from the ter.sncf.com schedule page",

--- a/Back/src/departures/departures.module.ts
+++ b/Back/src/departures/departures.module.ts
@@ -4,6 +4,7 @@ import { CrawlFlareService } from "../crawl/crawl-flare.service";
 import { CrawlService } from "../crawl/crawl.service";
 import { GtfsService } from "../gtfs/gtfs.service";
 import { PrimService } from "../prim/prim.service";
+import { SiriEtService } from "../siri-et/siri-et.service";
 import { SncfService } from "../sncf/sncf.service";
 import { DeparturesController } from "./departures.controller";
 import { DeparturesService } from "./departures.service";
@@ -15,6 +16,7 @@ import { DeparturesService } from "./departures.service";
     SncfService,
     GtfsService,
     PrimService,
+    SiriEtService,
     CrawlService,
     CrawlFlareService,
   ],

--- a/Back/src/departures/departures.service.spec.ts
+++ b/Back/src/departures/departures.service.spec.ts
@@ -7,6 +7,7 @@ import type { CrawlFlareService } from "../crawl/crawl-flare.service";
 import type { CrawlService } from "../crawl/crawl.service";
 import type { GtfsService } from "../gtfs/gtfs.service";
 import type { PrimService } from "../prim/prim.service";
+import type { SiriEtService } from "../siri-et/siri-et.service";
 import type { SncfService } from "../sncf/sncf.service";
 import { TrainType } from "../types/CrawlFlareDeparture";
 import { DeparturesService } from "./departures.service";
@@ -22,6 +23,7 @@ type Stubs = {
   sncf?: Partial<SncfService>;
   gtfs?: Partial<GtfsService>;
   prim?: Partial<PrimService>;
+  siriEt?: Partial<SiriEtService>;
   crawl?: Partial<CrawlService>;
   crawlFlare?: Partial<CrawlFlareService>;
   config?: Record<string, unknown>;
@@ -37,6 +39,7 @@ function makeService(stubs: Stubs = {}) {
     },
     gtfs: { getFeed: async () => null },
     prim: { getDepartures: async () => ({ isCached: false, data: [] }) },
+    siriEt: { getJourneys: async () => ({ isCached: false, data: [] }) },
     crawl: {
       getDeparturesSafe: async () => [],
       getDepartures: async () => ({ isCached: false, data: [] }),
@@ -49,6 +52,7 @@ function makeService(stubs: Stubs = {}) {
     { ...defaults.sncf, ...stubs.sncf } as SncfService,
     { ...defaults.gtfs, ...stubs.gtfs } as GtfsService,
     { ...defaults.prim, ...stubs.prim } as PrimService,
+    { ...defaults.siriEt, ...stubs.siriEt } as SiriEtService,
     { ...defaults.crawl, ...stubs.crawl } as CrawlService,
     { ...defaults.crawlFlare, ...stubs.crawlFlare } as CrawlFlareService,
   );

--- a/Back/src/departures/departures.service.ts
+++ b/Back/src/departures/departures.service.ts
@@ -11,10 +11,12 @@ import crawlsData from "../config/crawl-data";
 import { RT_FETCH_TYPES } from "../config/env.validation";
 import linesData from "../config/lines-data";
 import primsData from "../config/prim-data";
+import siriBoards from "../config/siri-data";
 import { CrawlFlareService } from "../crawl/crawl-flare.service";
 import { CrawlService } from "../crawl/crawl.service";
 import { GtfsService } from "../gtfs/gtfs.service";
 import { PrimService } from "../prim/prim.service";
+import { SiriEtService } from "../siri-et/siri-et.service";
 import { SncfService } from "../sncf/sncf.service";
 import type { CrawlFlareDeparture } from "../types/CrawlFlareDeparture";
 import type { TrainType } from "../types/CrawlFlareDeparture";
@@ -47,6 +49,7 @@ import {
   getDeparturesFromScheduledAndPrim,
   parsePrimDeliveries,
 } from "./prim.utils";
+import { buildBoardFromSiriJourneys } from "./siri.utils";
 
 @Injectable()
 export class DeparturesService {
@@ -59,6 +62,7 @@ export class DeparturesService {
     private readonly sncf: SncfService,
     private readonly gtfs: GtfsService,
     private readonly prim: PrimService,
+    private readonly siriEt: SiriEtService,
     private readonly crawl: CrawlService,
     private readonly crawlFlare: CrawlFlareService,
   ) {
@@ -437,6 +441,52 @@ export class DeparturesService {
     }
 
     return departures;
+  }
+
+  // --- SIRI ET ---------------------------------------------------------
+
+  findSiriBoard(id: number) {
+    const board = siriBoards.find((b) => b.id === id);
+
+    if (!board) {
+      throw new NotFoundException("Siri board not found");
+    }
+
+    return board;
+  }
+
+  private async getSiriJourneysOrThrow() {
+    const journeys = await this.siriEt.getJourneys();
+
+    if (!journeys) {
+      throw new ServiceUnavailableException("Error while fetching SIRI ET");
+    }
+
+    return journeys;
+  }
+
+  async getSiriBoard(id: number): Promise<DeparturesResponse> {
+    const board = this.findSiriBoard(id);
+    const journeys = await this.getSiriJourneysOrThrow();
+
+    const res = buildBoardFromSiriJourneys(board, journeys);
+    this.logger.debug(
+      `siri board=${board.id} (${board.departureName}): ${res.data.length} departures from ${journeys.data.length} journeys`,
+    );
+
+    return res;
+  }
+
+  async getSiriBoardsByType(type: string): Promise<DeparturesResponse[]> {
+    const boards = siriBoards.filter((board) => board.type === type);
+
+    if (!boards.length) {
+      throw new NotFoundException("Siri board not found");
+    }
+
+    const journeys = await this.getSiriJourneysOrThrow();
+
+    return boards.map((board) => buildBoardFromSiriJourneys(board, journeys));
   }
 
   // --- crawls ----------------------------------------------------------

--- a/Back/src/departures/dto/departures.dto.ts
+++ b/Back/src/departures/dto/departures.dto.ts
@@ -25,7 +25,7 @@ export const trainResponseSchema = z.object({
 export const departuresResponseSchema = z.object({
   title: z.string(),
   data: z.array(trainResponseSchema),
-  fetchType: z.enum(RT_FETCH_TYPES),
+  fetchType: z.enum([...RT_FETCH_TYPES, "siri"]),
   isCached: z
     .boolean()
     .meta({ description: "True when served from the Redis/in-memory cache" }),

--- a/Back/src/departures/siri.utils.spec.ts
+++ b/Back/src/departures/siri.utils.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+
+import siriBoards from "../config/siri-data";
+import type { SiriJourney } from "../types/SiriEt";
+import { buildBoardFromSiriJourneys } from "./siri.utils";
+
+const NOW = new Date("2026-07-24T14:00:00Z"); // 16:00 Paris
+
+const etampesBoard = siriBoards[0]; // Étampes -> Austerlitz
+const austerlitzBoard = siriBoards[1]; // Austerlitz -> Étampes
+
+function journey(over: Partial<SiriJourney> & { calls: SiriJourney["calls"] }): SiriJourney {
+  return { cancelled: false, ...over };
+}
+
+// RER C: Austerlitz -> Étampes, 2 min delay, platform 3
+const rerCsouth = journey({
+  trainNumber: "145435",
+  lineRef: "C",
+  destinationName: "Saint-Martin d'Étampes",
+  calls: [
+    {
+      stopRef: "FR:ScheduledStopPoint::87547026",
+      aimedDepartureTime: "2026-07-24T14:30:00Z",
+      expectedDepartureTime: "2026-07-24T14:32:00Z",
+      departurePlatform: "3",
+    },
+    {
+      stopRef: "FR:ScheduledStopPoint::87545137",
+      expectedArrivalTime: "2026-07-24T15:29:00Z",
+    },
+  ],
+});
+
+// Rémi: Étampes -> Austerlitz, platform 4
+const remiNorth = journey({
+  trainNumber: "860500",
+  lineRef: "FR:Line::X:",
+  destinationName: "Paris Austerlitz",
+  calls: [
+    {
+      stopRef: "FR:ScheduledStopPoint::87545137",
+      aimedDepartureTime: "2026-07-24T14:20:00Z",
+      expectedDepartureTime: "2026-07-24T14:20:00Z",
+      departurePlatform: "4",
+    },
+    {
+      stopRef: "FR:ScheduledStopPoint::87547000",
+      expectedArrivalTime: "2026-07-24T15:20:00Z",
+    },
+  ],
+});
+
+describe("buildBoardFromSiriJourneys", () => {
+  it("builds the Austerlitz→Étampes board with delay, platform and type", () => {
+    const res = buildBoardFromSiriJourneys(
+      austerlitzBoard,
+      { isCached: false, data: [rerCsouth, remiNorth] },
+      NOW,
+    );
+
+    expect(res.fetchType).toBe("siri");
+    expect(res.title).toContain("Austerlitz");
+    expect(res.data).toHaveLength(1); // only the southbound RER C
+    expect(res.data[0]).toMatchObject({
+      title: "Étampes",
+      departureTime: "16:32",
+      delay: 2,
+      dock: "3",
+      trainType: "RER",
+      trainNumber: "145435",
+    });
+  });
+
+  it("builds the Étampes→Austerlitz board (opposite direction)", () => {
+    const res = buildBoardFromSiriJourneys(
+      etampesBoard,
+      { isCached: true, data: [rerCsouth, remiNorth] },
+      NOW,
+    );
+
+    expect(res.isCached).toBe(true);
+    expect(res.data).toHaveLength(1); // only the northbound Rémi
+    expect(res.data[0]).toMatchObject({
+      departureTime: "16:20",
+      dock: "4",
+      trainType: "TER",
+    });
+  });
+
+  it("excludes a train that does not call at the destination stop", () => {
+    // Orléans express: departs Austerlitz but never calls at Étampes
+    const express = journey({
+      trainNumber: "860999",
+      destinationName: "Orléans",
+      calls: [
+        {
+          stopRef: "FR:ScheduledStopPoint::87547000",
+          expectedDepartureTime: "2026-07-24T14:40:00Z",
+        },
+        {
+          stopRef: "FR:ScheduledStopPoint::87999999",
+          expectedArrivalTime: "2026-07-24T15:40:00Z",
+        },
+      ],
+    });
+
+    const res = buildBoardFromSiriJourneys(
+      austerlitzBoard,
+      { isCached: false, data: [express] },
+      NOW,
+    );
+
+    expect(res.data).toHaveLength(0);
+  });
+
+  it("drops departures already in the past", () => {
+    const res = buildBoardFromSiriJourneys(
+      austerlitzBoard,
+      { isCached: false, data: [rerCsouth] },
+      new Date("2026-07-24T15:00:00Z"), // 17:00 Paris, well after 16:32
+    );
+
+    expect(res.data).toHaveLength(0);
+  });
+
+  it("flags a cancelled journey as deleted", () => {
+    const res = buildBoardFromSiriJourneys(
+      austerlitzBoard,
+      { isCached: false, data: [{ ...rerCsouth, cancelled: true }] },
+      NOW,
+    );
+
+    expect(res.data[0].deleted).toBe(true);
+  });
+});

--- a/Back/src/departures/siri.utils.ts
+++ b/Back/src/departures/siri.utils.ts
@@ -1,0 +1,98 @@
+import { differenceInMinutes, format, parseISO } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+
+import type { IsCached } from "../types/IsCached";
+import type { DeparturesResponse, TrainResponse } from "../types/Response";
+import type { SiriBoard, SiriCall, SiriJourney } from "../types/SiriEt";
+
+/** Departures older than this are dropped from the board. */
+const PAST_GRACE_MINUTES = 2;
+
+function findCall(calls: SiriCall[], uics: string[]): SiriCall | undefined {
+  return calls.find((call) => uics.some((uic) => call.stopRef.endsWith(uic)));
+}
+
+function toParisTime(iso: string): string {
+  return formatInTimeZone(iso, "Europe/Paris", "HH:mm");
+}
+
+/**
+ * Build one departure board from the parsed SIRI ET journeys: keep journeys
+ * that call at the board's departure stop and later at its destination stop
+ * (the calling list makes stop-vs-skip unambiguous), then map the departure
+ * call to a TrainResponse with delay and platform.
+ */
+export function buildBoardFromSiriJourneys(
+  board: SiriBoard,
+  journeys: IsCached<SiriJourney[]>,
+  now: Date = new Date(),
+): DeparturesResponse {
+  const entries: { departureIso: string; train: TrainResponse }[] = [];
+
+  for (const journey of journeys.data) {
+    const fromCall = findCall(journey.calls, board.fromUics);
+    const toCall = findCall(journey.calls, board.toUics);
+
+    if (!fromCall || !toCall) continue;
+
+    const departureIso =
+      fromCall.expectedDepartureTime ?? fromCall.aimedDepartureTime;
+    const toIso =
+      toCall.expectedArrivalTime ??
+      toCall.aimedArrivalTime ??
+      toCall.expectedDepartureTime ??
+      toCall.aimedDepartureTime;
+
+    if (!departureIso || !toIso) continue;
+
+    // Direction: the journey must depart here before reaching the other stop.
+    if (parseISO(departureIso) >= parseISO(toIso)) continue;
+
+    // Skip trains that already left.
+    if (
+      differenceInMinutes(parseISO(departureIso), now) < -PAST_GRACE_MINUTES
+    ) {
+      continue;
+    }
+
+    const arrivalIso = fromCall.expectedArrivalTime ?? fromCall.aimedArrivalTime;
+
+    const train: TrainResponse = {
+      title: board.destinationName,
+      departureTime: toParisTime(departureIso),
+      arrivalTime: arrivalIso ? toParisTime(arrivalIso) : toParisTime(departureIso),
+      trainNumber: journey.trainNumber,
+      trainType: journey.lineRef === "C" ? "RER" : "TER",
+    };
+
+    if (fromCall.aimedDepartureTime && fromCall.expectedDepartureTime) {
+      const delay = differenceInMinutes(
+        parseISO(fromCall.expectedDepartureTime),
+        parseISO(fromCall.aimedDepartureTime),
+      );
+      if (delay) {
+        train.delay = delay;
+      }
+    }
+
+    const dock = fromCall.departurePlatform ?? fromCall.arrivalPlatform;
+    if (dock) {
+      train.dock = dock;
+    }
+
+    if (journey.cancelled) {
+      train.deleted = true;
+    }
+
+    entries.push({ departureIso, train });
+  }
+
+  entries.sort((a, b) => a.departureIso.localeCompare(b.departureIso));
+
+  return {
+    title: `${board.departureName} - ${format(now, "dd/MM")}`,
+    data: entries.map((entry) => entry.train),
+    isCached: journeys.isCached,
+    fetchType: "siri",
+  };
+}

--- a/Back/src/siri-et/siri-et.fixture.ts
+++ b/Back/src/siri-et/siri-et.fixture.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal SIRI ET Lite fixture modelled on the real national feed: one RER C
+ * journey Austerlitz→Étampes (platform + 2 min delay), one mainline Rémi
+ * Étampes→Austerlitz, and one Orléans express that does NOT call at Étampes.
+ */
+export const SIRI_ET_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<Siri xmlns="http://www.siri.org.uk/siri" version="2.0"><ServiceDelivery>
+<EstimatedTimetableDelivery version="2.0"><EstimatedJourneyVersionFrame>
+
+<EstimatedVehicleJourney>
+  <LineRef>C</LineRef>
+  <FramedVehicleJourneyRef><DatedVehicleJourneyRef>FR:VehicleJourney::145435f2c9ed:LOC</DatedVehicleJourneyRef></FramedVehicleJourneyRef>
+  <OriginName>Paris Austerlitz RER C</OriginName>
+  <DestinationName>Saint-Martin d'Étampes</DestinationName>
+  <EstimatedCalls>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87547026</StopPointRef>
+      <StopPointName>Paris Austerlitz RER C</StopPointName>
+      <AimedDepartureTime>2026-07-24T14:30:00Z</AimedDepartureTime>
+      <ExpectedDepartureTime>2026-07-24T14:32:00Z</ExpectedDepartureTime>
+      <DeparturePlatformName>3</DeparturePlatformName>
+    </EstimatedCall>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87545137</StopPointRef>
+      <StopPointName>Étampes</StopPointName>
+      <AimedArrivalTime>2026-07-24T15:27:00Z</AimedArrivalTime>
+      <ExpectedArrivalTime>2026-07-24T15:29:00Z</ExpectedArrivalTime>
+      <ArrivalPlatformName>3</ArrivalPlatformName>
+    </EstimatedCall>
+  </EstimatedCalls>
+</EstimatedVehicleJourney>
+
+<EstimatedVehicleJourney>
+  <LineRef>FR:Line::89BD9468:</LineRef>
+  <FramedVehicleJourneyRef><DatedVehicleJourneyRef>FR:VehicleJourney::860589d366:LOC</DatedVehicleJourneyRef></FramedVehicleJourneyRef>
+  <OriginName>Paris Austerlitz</OriginName>
+  <DestinationName>Orléans</DestinationName>
+  <EstimatedCalls>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87547000</StopPointRef>
+      <StopPointName>Paris Austerlitz</StopPointName>
+      <AimedDepartureTime>2026-07-24T14:35:00Z</AimedDepartureTime>
+      <ExpectedDepartureTime>2026-07-24T14:35:00Z</ExpectedDepartureTime>
+    </EstimatedCall>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87545137</StopPointRef>
+      <StopPointName>Étampes</StopPointName>
+      <AimedArrivalTime>2026-07-24T15:06:00Z</AimedArrivalTime>
+      <ExpectedArrivalTime>2026-07-24T15:06:00Z</ExpectedArrivalTime>
+      <AimedDepartureTime>2026-07-24T15:08:00Z</AimedDepartureTime>
+      <ExpectedDepartureTime>2026-07-24T15:08:00Z</ExpectedDepartureTime>
+      <ArrivalPlatformName>1</ArrivalPlatformName>
+    </EstimatedCall>
+  </EstimatedCalls>
+</EstimatedVehicleJourney>
+
+<EstimatedVehicleJourney>
+  <LineRef>FR:Line::AAAA:</LineRef>
+  <FramedVehicleJourneyRef><DatedVehicleJourneyRef>FR:VehicleJourney::860613f0fe:LOC</DatedVehicleJourneyRef></FramedVehicleJourneyRef>
+  <OriginName>Paris Austerlitz</OriginName>
+  <DestinationName>Châteaudun</DestinationName>
+  <EstimatedCalls>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87547000</StopPointRef>
+      <StopPointName>Paris Austerlitz</StopPointName>
+      <AimedDepartureTime>2026-07-24T14:25:00Z</AimedDepartureTime>
+      <ExpectedDepartureTime>2026-07-24T14:25:00Z</ExpectedDepartureTime>
+    </EstimatedCall>
+    <EstimatedCall>
+      <StopPointRef>FR:ScheduledStopPoint::87411443</StopPointRef>
+      <StopPointName>Châteaudun</StopPointName>
+      <AimedArrivalTime>2026-07-24T16:00:00Z</AimedArrivalTime>
+    </EstimatedCall>
+  </EstimatedCalls>
+</EstimatedVehicleJourney>
+
+</EstimatedJourneyVersionFrame></EstimatedTimetableDelivery>
+</ServiceDelivery></Siri>`;

--- a/Back/src/siri-et/siri-et.service.spec.ts
+++ b/Back/src/siri-et/siri-et.service.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { ConfigService } from "@nestjs/config";
+
+import { FakeCacheService, restoreFetch, stubFetch } from "../testing/fakes";
+import { SIRI_ET_FIXTURE } from "./siri-et.fixture";
+import { SiriEtService } from "./siri-et.service";
+
+function makeService(cache = new FakeCacheService()) {
+  const config = new ConfigService({
+    SNCF_SIRI_ET_URL: "https://feed.example.com/siri-et",
+  });
+  return { service: new SiriEtService(config, cache.asCacheService()), cache };
+}
+
+afterEach(() => {
+  restoreFetch();
+});
+
+describe("SiriEtService.parseFeed", () => {
+  it("extracts journeys calling at the watched stops, with calls and platforms", () => {
+    const { service } = makeService();
+
+    const journeys = service.parseFeed(SIRI_ET_FIXTURE);
+
+    // all three fixture journeys touch Austerlitz or Étampes
+    expect(journeys).toHaveLength(3);
+
+    const rerC = journeys.find((j) => j.trainNumber === "145435");
+    expect(rerC).toBeDefined();
+    expect(rerC?.lineRef).toBe("C");
+    expect(rerC?.destinationName).toBe("Saint-Martin d'Étampes");
+    expect(rerC?.calls).toHaveLength(2);
+    expect(rerC?.calls[0].departurePlatform).toBe("3");
+    expect(rerC?.calls[0].expectedDepartureTime).toBe("2026-07-24T14:32:00Z");
+  });
+
+  it("extracts the 6-digit train number from the journey ref", () => {
+    const { service } = makeService();
+    const journeys = service.parseFeed(SIRI_ET_FIXTURE);
+    expect(journeys.map((j) => j.trainNumber).sort()).toEqual([
+      "145435",
+      "860589",
+      "860613",
+    ]);
+  });
+});
+
+describe("SiriEtService.getJourneys", () => {
+  it("fetches, caches, and serves the next call from memory", async () => {
+    const { service, cache } = makeService();
+    const { calls } = stubFetch(async () => new Response(SIRI_ET_FIXTURE));
+
+    const first = await service.getJourneys();
+    const second = await service.getJourneys();
+
+    expect(first?.isCached).toBe(false);
+    expect(first?.data).toHaveLength(3);
+    expect(second?.isCached).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(cache.jsonWrites[0]).toEqual({
+      key: "siriET:journeys",
+      ttlSeconds: 60,
+    });
+  });
+
+  it("returns null when the feed cannot be fetched", async () => {
+    const { service } = makeService();
+    stubFetch(async () => new Response("nope", { status: 502 }));
+
+    expect(await service.getJourneys()).toBeNull();
+  });
+});

--- a/Back/src/siri-et/siri-et.service.ts
+++ b/Back/src/siri-et/siri-et.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { XMLParser } from "fast-xml-parser";
+
+import siriBoards from "../config/siri-data";
+import { CacheService } from "../redis/cache.service";
+import type { IsCached } from "../types/IsCached";
+import type { SiriCall, SiriJourney } from "../types/SiriEt";
+
+const DEFAULT_FEED_URL =
+  "https://proxy.transport.data.gouv.fr/resource/sncf-siri-lite-estimated-timetable";
+
+const REDIS_KEY = "siriET:journeys";
+const TTL_SECONDS = 60;
+const MEM_TTL_MS = 60_000;
+
+/** Tags that must always parse as arrays even with a single element. */
+const ARRAY_TAGS = new Set([
+  "EstimatedTimetableDelivery",
+  "EstimatedJourneyVersionFrame",
+  "EstimatedVehicleJourney",
+  "RecordedCall",
+  "EstimatedCall",
+]);
+
+/**
+ * Reader for the national SNCF SIRI ET Lite feed (realtime estimated
+ * timetables for every TGV/Intercités/TER, with platforms — keyless, from
+ * the transport.data.gouv.fr proxy).
+ *
+ * The raw feed is a ~15 MB XML covering all of France, so it is parsed once
+ * and reduced to the journeys calling at the stops configured in
+ * `siri-data.ts`; only that small filtered set is cached (in-process +
+ * Redis) — same strategy as the GTFS-RT reader.
+ */
+@Injectable()
+export class SiriEtService {
+  private readonly logger = new Logger(SiriEtService.name);
+  private readonly url: string;
+  private readonly watchedUics: string[];
+
+  private memCache?: { journeys: SiriJourney[]; fetchedAt: number };
+
+  constructor(
+    config: ConfigService,
+    private readonly cache: CacheService,
+  ) {
+    this.url = config.get<string>("SNCF_SIRI_ET_URL") ?? DEFAULT_FEED_URL;
+    this.watchedUics = [
+      ...new Set(siriBoards.flatMap((board) => [...board.fromUics, ...board.toUics])),
+    ];
+  }
+
+  async getJourneys(): Promise<IsCached<SiriJourney[]> | null> {
+    if (this.memCache && Date.now() - this.memCache.fetchedAt < MEM_TTL_MS) {
+      this.logger.debug(
+        `In-memory cache hit (${this.memCache.journeys.length} journeys)`,
+      );
+      return { isCached: true, data: this.memCache.journeys };
+    }
+
+    const cached = await this.cache.getJson<SiriJourney[]>(REDIS_KEY);
+
+    if (cached) {
+      this.logger.debug(`Cache hit ${REDIS_KEY} (${cached.length} journeys)`);
+      this.memCache = { journeys: cached, fetchedAt: Date.now() };
+      return { isCached: true, data: cached };
+    }
+
+    this.logger.debug(`Cache miss — fetching SIRI ET feed from ${this.url}`);
+    const startedAt = Date.now();
+
+    try {
+      const res = await fetch(this.url);
+      if (!res.ok) {
+        throw new Error(`HTTP error! status: ${res.status}`);
+      }
+      const xml = await res.text();
+      const journeys = this.parseFeed(xml);
+
+      this.logger.debug(
+        `Parsed ${Math.round(xml.length / 1024)} KB in ${Date.now() - startedAt}ms — ${journeys.length} journeys at watched stops`,
+      );
+
+      if (!journeys.length) {
+        this.logger.warn("SIRI ET feed contained no journeys at watched stops");
+      }
+
+      this.cache.setJson(REDIS_KEY, journeys, TTL_SECONDS);
+      this.memCache = { journeys, fetchedAt: Date.now() };
+
+      return { isCached: false, data: journeys };
+    } catch (err) {
+      this.logger.error(`SIRI ET fetch failed: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /** Parse the feed and keep only journeys calling at a watched stop. */
+  parseFeed(xml: string): SiriJourney[] {
+    const parser = new XMLParser({
+      ignoreAttributes: true,
+      parseTagValue: false,
+      isArray: (name) => ARRAY_TAGS.has(name),
+    });
+
+    const doc = parser.parse(xml);
+    const deliveries =
+      doc?.Siri?.ServiceDelivery?.EstimatedTimetableDelivery ?? [];
+
+    const journeys: SiriJourney[] = [];
+
+    for (const delivery of deliveries) {
+      for (const frame of delivery?.EstimatedJourneyVersionFrame ?? []) {
+        for (const vj of frame?.EstimatedVehicleJourney ?? []) {
+          const calls = [
+            ...(vj?.RecordedCalls?.RecordedCall ?? []),
+            ...(vj?.EstimatedCalls?.EstimatedCall ?? []),
+          ].map((call) => this.parseCall(call));
+
+          if (
+            !calls.some((call) =>
+              this.watchedUics.some((uic) => call.stopRef.endsWith(uic)),
+            )
+          ) {
+            continue;
+          }
+
+          journeys.push({
+            trainNumber: extractTrainNumber(
+              vj?.FramedVehicleJourneyRef?.DatedVehicleJourneyRef ??
+                vj?.DatedVehicleJourneyRef,
+            ),
+            lineRef: vj?.LineRef ? String(vj.LineRef) : undefined,
+            originName: vj?.OriginName ? String(vj.OriginName) : undefined,
+            destinationName: vj?.DestinationName
+              ? String(vj.DestinationName)
+              : undefined,
+            cancelled: String(vj?.Cancellation) === "true",
+            calls,
+          });
+        }
+      }
+    }
+
+    return journeys;
+  }
+
+  private parseCall(call: Record<string, unknown>): SiriCall {
+    const str = (v: unknown) => (v == null ? undefined : String(v));
+
+    return {
+      stopRef: str(call.StopPointRef) ?? "",
+      stopName: str(call.StopPointName),
+      aimedArrivalTime: str(call.AimedArrivalTime),
+      expectedArrivalTime: str(call.ExpectedArrivalTime),
+      aimedDepartureTime: str(call.AimedDepartureTime),
+      expectedDepartureTime: str(call.ExpectedDepartureTime),
+      arrivalPlatform: str(call.ArrivalPlatformName),
+      departurePlatform: str(call.DeparturePlatformName),
+    };
+  }
+}
+
+/**
+ * The 6-digit SNCF train number is the prefix of the DatedVehicleJourneyRef
+ * hash: "FR:VehicleJourney::860589d36696…:LOC" -> "860589".
+ */
+function extractTrainNumber(ref?: string): string | undefined {
+  const match = ref?.match(/::(\d{6})/);
+  return match?.[1];
+}

--- a/Back/src/types/Response.ts
+++ b/Back/src/types/Response.ts
@@ -15,6 +15,7 @@ export type TrainResponse = {
 export type DeparturesResponse = {
   title: string;
   data: TrainResponse[];
-  fetchType: RTFetchType;
+  /** RTFetchType covers the scheduled-merge flows; "siri" is board-only. */
+  fetchType: RTFetchType | "siri";
   isCached: boolean;
 };

--- a/Back/src/types/SiriEt.ts
+++ b/Back/src/types/SiriEt.ts
@@ -1,0 +1,37 @@
+/** One stop call of a vehicle journey in the SIRI ET feed. */
+export interface SiriCall {
+  /** e.g. "FR:ScheduledStopPoint::87545137" — ends with the UIC code. */
+  stopRef: string;
+  stopName?: string;
+  aimedArrivalTime?: string;
+  expectedArrivalTime?: string;
+  aimedDepartureTime?: string;
+  expectedDepartureTime?: string;
+  arrivalPlatform?: string;
+  departurePlatform?: string;
+}
+
+/** A vehicle journey extracted from the national SIRI ET Lite feed. */
+export interface SiriJourney {
+  /** 6-digit SNCF train number (e.g. "860589"), when extractable. */
+  trainNumber?: string;
+  /** "C" for RER C journeys, otherwise a FR:Line:: reference. */
+  lineRef?: string;
+  originName?: string;
+  destinationName?: string;
+  cancelled: boolean;
+  /** All calls (recorded + estimated), in journey order. */
+  calls: SiriCall[];
+}
+
+/** A departure board built from the SIRI ET feed. */
+export interface SiriBoard {
+  id: number;
+  departureName: string;
+  destinationName: string;
+  /** UIC codes of the departure stop (several for multi-part stations). */
+  fromUics: string[];
+  /** UIC codes the journey must call at afterwards (direction filter). */
+  toUics: string[];
+  type: string;
+}

--- a/Scriptable/KrampNCF Full.js
+++ b/Scriptable/KrampNCF Full.js
@@ -35,9 +35,9 @@ const addStackFromReqData = (reqData, hours) => {
 	});
 }
 
-// PRIM realtime for every board (both directions: Étampes→Austerlitz and
-// Austerlitz→Étampes, each mixing RER C and TER).
-const url = Conf.getUrlDeparturesPrimByType('train');
+// SIRI ET realtime for every board (both directions: Étampes→Austerlitz and
+// Austerlitz→Étampes, each mixing RER C and mainline Rémi).
+const url = Conf.getUrlDeparturesSiriByType('train');
 const req = new Request(url);
 const reqData = await req.loadJSON();
 

--- a/Scriptable/KrampNCF-Conf.js
+++ b/Scriptable/KrampNCF-Conf.js
@@ -23,6 +23,14 @@ const getUrlDeparturesPrimById = (idDeparture) => {
   return `https://${token}@sncf.krampflix.ovh/departuresPrim/${idDeparture}`;
 }
 
+const getUrlDeparturesSiriById = (idDeparture) => {
+  return `https://${token}@sncf.krampflix.ovh/departuresSiri/${idDeparture}`;
+}
+
+const getUrlDeparturesSiriByType = (type) => {
+  return `https://${token}@sncf.krampflix.ovh/departuresSiriByType/${type}`;
+}
+
 const getUrlDeparturesCrawlById = (id, type) => {
   const typeParam = type ? `?type=${type}` : '';
   return `https://${token}@sncf.krampflix.ovh/departuresCrawlFlare/${id}/${typeParam}`;
@@ -35,4 +43,6 @@ const getUrlDeparturesCrawl = (type) => {
 
 module.exports = { getUrlDepartures,  getUrlDeparturesCrawlById, getUrlDeparturesCrawl,
 getUrlDeparturesPrimById,
-getUrlDeparturesPrimByType, correspUrlTrain };
+getUrlDeparturesPrimByType,
+getUrlDeparturesSiriById,
+getUrlDeparturesSiriByType, correspUrlTrain };

--- a/Scriptable/krampncf-rt.js
+++ b/Scriptable/krampncf-rt.js
@@ -27,8 +27,8 @@ stack.layoutHorizontally();
 stack.topAlignContent();
 
 
-// PRIM realtime for both boards (Étampes→Austerlitz and Austerlitz→Étampes).
-const url = Conf.getUrlDeparturesPrimByType('train');
+// SIRI ET realtime for both boards (Étampes→Austerlitz and Austerlitz→Étampes).
+const url = Conf.getUrlDeparturesSiriByType('train');
 const req = new Request(url);
 const reqData = await req.loadJSON();
 

--- a/Scriptable/krampncf.js
+++ b/Scriptable/krampncf.js
@@ -29,9 +29,9 @@ stack.layoutHorizontally();
 stack.topAlignContent();
 stack.setPadding(10, 0, 5, 0);
 
-// PRIM realtime for one direction (widget param: 1 = Étampes→Austerlitz,
-// 2 = Austerlitz→Étampes; defaults to 1).
-const url = Conf.getUrlDeparturesPrimById(idDeparture || 1);
+// SIRI ET realtime for one direction (widget param: 1 = Étampes→Austerlitz,
+// 2 = Austerlitz→Étampes; defaults to 1). Covers RER C + mainline Rémi.
+const url = Conf.getUrlDeparturesSiriById(idDeparture || 1);
 const req = new Request(url);
 const reqData = await req.loadJSON();
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - SNCF_API_URL=${SNCF_API_URL:-https://api.sncf.com/v1}
       - SNCF_API_KEY=${SNCF_API_KEY}
       - SNCF_GTFSRT_URL=${SNCF_GTFSRT_URL:-https://proxy.transport.data.gouv.fr/resource/sncf-ter-gtfs-rt-trip-updates}
+      - SNCF_SIRI_ET_URL=${SNCF_SIRI_ET_URL:-}
       - SNCF_API_PRIM_URL=${SNCF_API_PRIM_URL:-}
       - SNCF_API_PRIM_KEY=${SNCF_API_PRIM_KEY:-}
       - SNCF_CRAWL_URL=${SNCF_CRAWL_URL:-}


### PR DESCRIPTION
## Summary

New realtime source built on the **national SNCF SIRI ET Lite feed** ([transport.data.gouv.fr proxy](https://transport.data.gouv.fr/datasets/horaires-sncf), keyless) — realtime estimated timetables for every TGV/Intercités/TER with **per-call platforms** and the **full calling pattern**. This closes the gaps left after the ter.sncf.com crawl died behind DataDome:

| Problem before | With SIRI ET |
|---|---|
| PRIM (IDFM) doesn't publish the mainline Rémi (e.g. the 16:35 Austerlitz→Orléans calling at Étampes, train 860589) | ✅ present in the national feed |
| No way to tell if a through-train stops at Étampes (Orléans/Châteaudun expresses) | ✅ the calling list makes it exact — expresses are excluded, no destination heuristics |
| Docks came from the dead crawl / partial PRIM | ✅ `Departure/ArrivalPlatformName` per call |

## Implementation

- **`SiriEtService`** — fetches the ~15 MB national XML, parses with `fast-xml-parser`, keeps only journeys calling at watched stops, caches the small filtered set (in-process + Redis, 60 s) — same strategy as the GTFS-RT reader. Train number from the journey ref, `LineRef "C"` → RER vs TER, `Cancellation` → `deleted`.
- **`siri-data.ts`** — Étampes ↔ Austerlitz boards by UIC (incl. the separate *Paris Austerlitz RER C* stop `87547026`).
- **`buildBoardFromSiriJourneys`** — direction = calls at departure stop *before* destination stop; delay from aimed vs expected; past departures dropped.
- **Endpoints**: `GET /departuresSiri/:id` (`?format=awtrix` supported) and `GET /departuresSiriByType/:type`, Swagger-documented.
- **Scriptable widgets** switched from the PRIM endpoints to the SIRI ones (PRIM endpoints remain available).
- Optional `SNCF_SIRI_ET_URL` env, defaulting to the national proxy; README data-source table updated.

## Verified live

```
GET /departuresSiri/2   (Austerlitz → Étampes)
  16:00 → Étampes  RER  voie C  #145431
  16:30 → Étampes  RER  voie B  #145435
  16:35 → Étampes  TER          #860589   ← the Rémi PRIM couldn't provide
```
Châteaudun express (skips Étampes) correctly excluded; both directions checked.

## Tests

91 pass — new coverage: feed parsing against an XML fixture, board building (both directions, delay/platform/type, express exclusion, past-departure filtering, cancellation flag), fetch/cache/failure behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)