### PR TITLE
Scriptable: train type small & non-bold in title

### DIFF
--- a/Scriptable/KrampNCF Full.js
+++ b/Scriptable/KrampNCF Full.js
@@ -42,12 +42,11 @@ const req = new Request(url);
 const reqData = await req.loadJSON();
 
 // Split into a Rémi (TER) table and a RER table, keeping both directions.
-// The type label is injected into the board title ("Étampes - 24/07" ->
-// "Étampes Rémi - 24/07") so it shows in each table header.
+// The type shows in each table header (small, non-bold) via typeLabel.
 const boardsByType = (boards, trainType, label) =>
   boards.map((board) => ({
     ...board,
-    title: board.title.replace(' - ', ` ${label} - `),
+    typeLabel: label,
     data: board.data.filter((train) => train.trainType === trainType),
   }));
 

--- a/Scriptable/KrampNCF-RER.js
+++ b/Scriptable/KrampNCF-RER.js
@@ -27,8 +27,8 @@ stack.layoutHorizontally();
 stack.topAlignContent();
 stack.setPadding(10, 0, 5, 0);
 
-// SIRI ET realtime for both directions, filtered to RER C only, with "RER"
-// injected into the board title ("Étampes - 24/07" -> "Étampes RER - 24/07").
+// SIRI ET realtime for both directions, filtered to RER C only, with a small
+// non-bold "RER" label shown in each board header (via typeLabel).
 const url = Conf.getUrlDeparturesSiriByType('train');
 const req = new Request(url);
 const reqData = await req.loadJSON();
@@ -36,7 +36,7 @@ const reqData = await req.loadJSON();
 const rerBoards = Array.isArray(reqData)
   ? reqData.map((board) => ({
       ...board,
-      title: board.title.replace(' - ', ' RER - '),
+      typeLabel: 'RER',
       data: board.data.filter((train) => train.trainType === 'RER'),
     }))
   : reqData;

--- a/Scriptable/SNCFModule.js
+++ b/Scriptable/SNCFModule.js
@@ -55,6 +55,15 @@ const makeTrainTitle = (trainStack, train) => {
 
   title.lineLimit = 1;
 
+  // Optional train type (e.g. "Rémi", "RER") shown small and non-bold,
+  // like the date, right after the station name.
+  if (train.typeLabel) {
+    titleStack.addSpacer(4);
+    const typeTitle = titleStack.addText(train.typeLabel);
+    typeTitle.font = new Font(fontText, 12);
+    typeTitle.lineLimit = 1;
+  }
+
   titleStack.addSpacer();
 
   const dateTitle = titleStack.addText(titleTrainExp[1]);


### PR DESCRIPTION
Small follow-up to #24: the type label ("Rémi" / "RER") was being merged into the bold station name, so it rendered bold and full-size. This shows it via a dedicated `typeLabel` field styled like the date (`fontText 12`, non-bold), right after the station name — so it reads "Étampes **Rémi**" with the type small and light.

Bonus: it restores the station's tap-URL, which the previous title-string mangling had broken (`setTrainUrl` matches on the station name).

- `SNCFModule.js` — `makeTrainTitle` renders `train.typeLabel` when present.
- `KrampNCF Full.js` / `KrampNCF-RER.js` — set `typeLabel` instead of rewriting the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)